### PR TITLE
Fix so the detection can say which object was correctly detected.

### DIFF
--- a/src/object/ObjectRecognizer.cpp
+++ b/src/object/ObjectRecognizer.cpp
@@ -103,6 +103,7 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
     aiLogStream* ai_stream_ = new aiLogStream(aiGetPredefinedLogStream(aiDefaultLogStream_STDOUT, NULL));
     aiAttachLogStream(ai_stream_);
 
+    int template_db_id = 0;
     BOOST_FOREACH(const object_recognition_core::db::Document & document, db_documents) {
       // Get the list of _attachments and figure out the original mesh
       std::vector<std::string> attachments_names = document.attachment_names();
@@ -128,12 +129,10 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
         }
       }
 
-      // Create a fake ID
-      static int i = 0;
-      household_id_to_db_id_[i] = document.get_field<std::string>("object_id");
+      household_id_to_db_id_[template_db_id] = document.get_field<std::string>("object_id");
 
       // Load the mesh through assimp
-      std::cout << "Loading model: " << document.id() << " for object id: " << household_id_to_db_id_[i];
+      std::cout << "Loading model: " << document.id() << " for object id: " << household_id_to_db_id_[template_db_id];
 
       const struct aiScene* scene = aiImportFile(mesh_path.c_str(), aiProcess_FindDegenerates |
       aiProcess_FindInvalidData |
@@ -186,11 +185,12 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
 
       min_z_[document.get_field<std::string>("object_id")] = min_z;
 
-      object_recognizer_.addObject(i, mesh_msg);
+      object_recognizer_.addObject(template_db_id, mesh_msg);
 
       std::cout << std::endl;
 
       aiReleaseImport(scene);
+      template_db_id++;
     }
 
     aiDetachAllLogStreams();


### PR DESCRIPTION
Before this patch the recognition was giving any detection the first item in the db as the matching result, now it correctly points out to the one that really matched.

![screenshot from 2014-03-08 16 27 15](https://f.cloud.github.com/assets/1721716/2365675/90cddff0-a6d6-11e3-9229-c873e1fa847b.png)

Working with real xtion and having 5 objects trained (big pringles, a bottle of energy drink, little pringles, a mug that looks like a camera lense, and a can of "alubias").
![screenshot from 2014-03-08 16 31 44](https://f.cloud.github.com/assets/1721716/2365681/cda1de5e-a6d6-11e3-8cae-a539a6be8faf.png)
![screenshot from 2014-03-08 16 31 50](https://f.cloud.github.com/assets/1721716/2365682/d07dcf8e-a6d6-11e3-9b73-a0b6de9f8442.png)
