### PR TITLE
Fix cloud frame

### DIFF
--- a/src/object/ObjectRecognizer.cpp
+++ b/src/object/ObjectRecognizer.cpp
@@ -338,7 +338,6 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
 
         // Add the pose
         const geometry_msgs::Pose &pose = result.pose_;
-
         cv::Vec3f T(pose.position.x, pose.position.y, pose.position.z);
         T[2] -= min_z_[object_id];
         Eigen::Quaternionf quat(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);


### PR DESCRIPTION
In the beginning of the process() function the point clusters are transformed to the table frame.

They need to be transformed back to the original frame before being published.
