### PR TITLE
Fix object pose by removing redundant z_min correction.

### DIFF
--- a/src/object/ObjectRecognizer.cpp
+++ b/src/object/ObjectRecognizer.cpp
@@ -183,8 +183,6 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
       for (size_t i = 0; i < mesh_msg.vertices.size(); ++i)
         mesh_msg.vertices[i].z -= min_z;
 
-      min_z_[document.get_field<std::string>("object_id")] = min_z;
-
       object_recognizer_.addObject(template_db_id, mesh_msg);
 
       std::cout << std::endl;
@@ -339,7 +337,7 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
         // Add the pose
         const geometry_msgs::Pose &pose = result.pose_;
         cv::Vec3f T(pose.position.x, pose.position.y, pose.position.z);
-        T[2] -= min_z_[object_id];
+
         Eigen::Quaternionf quat(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
 
         cv::Vec3f new_T = rotations[table_index] * T + translations[table_index];
@@ -392,8 +390,6 @@ struct ObjectRecognizer : public object_recognition_core::db::bases::ModelReader
     ecto::spore<std::string> tabletop_object_ids_;
   /** map to convert from artificial household id to db id */
   std::map<size_t, std::string> household_id_to_db_id_;
-  /** for each DB id, store the minimum z */
-  std::map<std::string, double> min_z_;
 };
 }
 


### PR DESCRIPTION
The min_z is subtracted twice.

First the mesh vertices are offset so that z=0 is the minimum for the mesh (in https://github.com/shadow-robot/tabletop/blob/a107a368d019557b69b77f281561fd80a8ac528b/src/object/ObjectRecognizer.cpp#L184)

Then the pose found for the object is offset again, leading to a wrong position for the object, as shown in the following image:

![rviz_object_recognition_bad_z](https://cloud.githubusercontent.com/assets/3338520/2606314/7758c3d2-bb4e-11e3-9207-1a865adade41.png)

Using the correction in this pull request the pose is in the right place (see the cam RGB image on the right side of the rviz screen):

![rviz_object_recognition_good_z](https://cloud.githubusercontent.com/assets/3338520/2606338/bb206da4-bb4e-11e3-9d18-cb43faa3afd0.png)
